### PR TITLE
Fix: fixed small issue in the readme and setup tool. added gitignore …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv
+__pycache__
+_build/

--- a/Readme.md
+++ b/Readme.md
@@ -50,9 +50,9 @@ git clone https://github.com/some-ip-com/open-someip-spec
 cd open-someip-spec
 ./tools/setup.sh
 source .venv/bin/activate
-cd tools
 make html
 ```
+Open `src/_build/html/index.html` in your browser.
 
 ## Licensing
 

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -12,7 +12,7 @@
 deactivate 2>/dev/null
 
 # create virtual environment
-python -m venv .venv
+python3 -m venv .venv
 
 # activate virtual environment
 source .venv/bin/activate


### PR DESCRIPTION
I just went through the readme and build the specification locally. Found some issue in the readme and fixed it (`make html` didn't work from tools folder). In the setup tool, python3 was not specified, I had some trouble with that. Just made it more robust with `python -> python3.` After building I noticed that git marked many files as new (for example in the .venv) just created a gitignore file.  